### PR TITLE
프론트엔드 절대 경로 설정

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -34,7 +34,8 @@
     "no-use-before-define": 0,
     "@typescript-eslint/no-var-requires": 0,
     "import/extensions": 0,
-    "import/no-unresolved": 0
+    "import/no-unresolved": 0,
+    "import/prefer-default-export": "off"
   },
   "settings": {
     "import/resolver": {

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -16,9 +16,9 @@ module.exports = {
     config.resolve.alias = {
       ...config.resolve.alias,
       '@': resolvePathFromRoot('src'),
-      '@asset': resolvePathFromRoot('src', 'asset'),
+      '@assets': resolvePathFromRoot('src', 'assets'),
       '@utils': resolvePathFromRoot('src', 'utils'),
-      '@component': resolvePathFromRoot('src', 'components'),
+      '@components': resolvePathFromRoot('src', 'components'),
       '@atoms': resolvePathFromRoot('src', 'components', 'atoms'),
       '@molecules': resolvePathFromRoot('src', 'components', 'molecules'),
       '@organisms': resolvePathFromRoot('src', 'components', 'organisms'),

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -1,3 +1,8 @@
+const path = require('path');
+
+const resolvePathFromRoot = (...pathSegments) =>
+  path.resolve(__dirname, '..', ...pathSegments);
+
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
@@ -7,4 +12,18 @@ module.exports = {
     '@storybook/addon-knobs',
     '@storybook/preset-create-react-app',
   ],
+  webpackFinal: async (config, { configType }) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@': resolvePathFromRoot('src'),
+      '@asset': resolvePathFromRoot('src', 'asset'),
+      '@utils': resolvePathFromRoot('src', 'utils'),
+      '@component': resolvePathFromRoot('src', 'components'),
+      '@atoms': resolvePathFromRoot('src', 'components', 'atoms'),
+      '@molecules': resolvePathFromRoot('src', 'components', 'molecules'),
+      '@organisms': resolvePathFromRoot('src', 'components', 'organisms'),
+      '@pages': resolvePathFromRoot('src', 'components', 'pages'),
+    };
+    return config;
+  },
 };

--- a/frontend/config-overrides.js
+++ b/frontend/config-overrides.js
@@ -1,0 +1,7 @@
+const { alias, configPaths } = require('react-app-rewire-alias');
+
+module.exports = function override(config) {
+  alias(configPaths('./tsconfig.paths.json'))(config);
+
+  return config;
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1197,16 +1197,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@craco/craco": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-5.8.0.tgz",
-      "integrity": "sha512-4rhusETLD7rJ195GxOK9VmVdv/VD4jawFxc9hcQ9TrZ3/9ny+qwc0uW+08qu9GYwEF9Eb9meSeSvpWjaqdDr1Q==",
-      "requires": {
-        "cross-spawn": "^7.0.0",
-        "lodash": "^4.17.15",
-        "webpack-merge": "^4.2.2"
-      }
-    },
     "@csstools/convert-colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
@@ -8455,11 +8445,6 @@
         }
       }
     },
-    "craco-alias": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/craco-alias/-/craco-alias-2.1.1.tgz",
-      "integrity": "sha512-rTYOcHYlcCES0XUOcUgcCOXe6s+FvR1dTupvMYfeLLtQ4NWW143i3KtATXlNegBDyj/dZqtBEv6OieGG3yPZzg=="
-    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -8508,44 +8493,6 @@
       "requires": {
         "gud": "^1.0.0",
         "warning": "^4.0.3"
-      }
-    },
-    "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "dependencies": {
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "crypto-browserify": {
@@ -17532,6 +17479,26 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "react-app-rewire-alias": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/react-app-rewire-alias/-/react-app-rewire-alias-0.1.8.tgz",
+      "integrity": "sha512-sEA0Khl5qAs+N/0vuDGjVMG6dqE7kJ9PnpwRtmGLQL9Jx3pnLrQFUb1M4wzIlvTH6tubfUT6tCzBQVUK+pdCWw=="
+    },
+    "react-app-rewired": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.6.tgz",
+      "integrity": "sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==",
+      "requires": {
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "react-color": {
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
@@ -25374,14 +25341,6 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
-      }
-    },
-    "webpack-merge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
-      "requires": {
-        "lodash": "^4.17.15"
       }
     },
     "webpack-sources": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@babel/core": "^7.12.7",
-    "@craco/craco": "^5.8.0",
     "@emotion/css": "^11.0.0",
     "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",
@@ -18,17 +17,18 @@
     "@types/react": "^16.14.1",
     "@types/react-dom": "^16.9.10",
     "babel-loader": "^8.1.0",
-    "craco-alias": "^2.1.1",
     "react": "^17.0.1",
+    "react-app-rewire-alias": "^0.1.8",
+    "react-app-rewired": "^2.1.6",
     "react-dom": "^17.0.1",
     "react-scripts": "^4.0.1",
     "typescript": "^4.1.2",
     "web-vitals": "^0.2.4"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,8 +2,8 @@
 /** @jsx jsx */
 import { jsx, css, Global } from '@emotion/react';
 
-import { Block, BlockType, Page } from './schemes';
-import PageComponent from './components/pages/PageComponent';
+import { Block, BlockType, Page } from '@/schemes';
+import { PageComponent } from '@components/pages';
 
 function App(): JSX.Element {
   const block01: Block = {

--- a/frontend/src/components/atoms/HeaderButton/HeaderButton.stories.tsx
+++ b/frontend/src/components/atoms/HeaderButton/HeaderButton.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import HeaderButton from './HeaderButton';
+import HeaderButton from '.';
 
 const desc = {
   component: HeaderButton,

--- a/frontend/src/components/atoms/HeaderLink/HeaderLink.stories.tsx
+++ b/frontend/src/components/atoms/HeaderLink/HeaderLink.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import HeaderLink from './HeaderLink';
+import HeaderLink from '.';
 
 const desc = {
   component: HeaderLink,

--- a/frontend/src/components/atoms/Heading/Heading.stories.tsx
+++ b/frontend/src/components/atoms/Heading/Heading.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Heading1, Heading2, Heading3 } from '.';
+
+import Heading from '.';
 
 const desc = {
-  component: Heading1,
+  component: Heading.Heading1,
   title: 'Atoms/Heading',
 };
 
@@ -11,7 +12,7 @@ export const HEADING1 = (): JSX.Element => {
     handleValue: () => {},
     content: { current: 'Heading1' },
   };
-  return <Heading1 {...headingProps} />;
+  return <Heading.Heading1 {...headingProps} />;
 };
 
 export const HEADING2 = (): JSX.Element => {
@@ -19,7 +20,7 @@ export const HEADING2 = (): JSX.Element => {
     handleValue: () => {},
     content: { current: 'Heading2' },
   };
-  return <Heading2 {...headingProps} />;
+  return <Heading.Heading2 {...headingProps} />;
 };
 
 export const HEADING3 = (): JSX.Element => {
@@ -27,7 +28,7 @@ export const HEADING3 = (): JSX.Element => {
     handleValue: () => {},
     content: { current: 'Heading3' },
   };
-  return <Heading3 {...headingProps} />;
+  return <Heading.Heading3 {...headingProps} />;
 };
 
 export default desc;

--- a/frontend/src/components/atoms/Heading/Heading.tsx
+++ b/frontend/src/components/atoms/Heading/Heading.tsx
@@ -6,7 +6,7 @@ const h1 = { margin: 5, fontSize: 'xx-large' };
 const h2 = { margin: 5, fontSize: 'x-large' };
 const h3 = { margin: 5, fontSize: 'large' };
 
-export interface HeadingProps {
+interface HeadingProps {
   handleValue: any;
   content: any;
 }
@@ -50,4 +50,4 @@ function Heading3(compoProps: HeadingProps): JSX.Element {
   );
 }
 
-export { Heading1, Heading2, Heading3 };
+export default { Heading1, Heading2, Heading3 };

--- a/frontend/src/components/atoms/Heading/index.ts
+++ b/frontend/src/components/atoms/Heading/index.ts
@@ -1,1 +1,1 @@
-export { Heading1, Heading2, Heading3 } from './Heading';
+export { default } from './Heading';

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -1,2 +1,3 @@
-export * as HeaderLink from './HeaderLink';
-export * as HeaderButton from './HeaderButton';
+export { default as HeaderLink } from './HeaderLink';
+export { default as HeaderButton } from './HeaderButton';
+export { default as Heading } from './Heading';

--- a/frontend/src/components/molecules/BlockComponent/BlockComponent.stories.tsx
+++ b/frontend/src/components/molecules/BlockComponent/BlockComponent.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import BlockComponent from './BlockComponent';
-import { Block, BlockType } from '../../../schemes';
+import { Block, BlockType } from '@/schemes';
+
+import BlockComponent from '.';
 
 const desc = {
   component: BlockComponent,
@@ -14,7 +15,7 @@ export const Default = (): JSX.Element => {
     type: BlockType.TEXT,
     value: 'Hello, Bootion!!',
   };
-  return <BlockComponent {...{ block }} />;
+  return <BlockComponent {...{ block, notifyHover: () => {} }} />;
 };
 
 export const HasDescendants = (): JSX.Element => {
@@ -47,7 +48,7 @@ export const HasDescendants = (): JSX.Element => {
       },
     ],
   };
-  return <BlockComponent {...{ block }} />;
+  return <BlockComponent {...{ block, notifyHover: () => {} }} />;
 };
 
 export const Grid = (): JSX.Element => {
@@ -114,7 +115,7 @@ export const Grid = (): JSX.Element => {
       },
     ],
   };
-  return <BlockComponent {...{ block }} />;
+  return <BlockComponent {...{ block, notifyHover: () => {} }} />;
 };
 
 export default desc;

--- a/frontend/src/components/molecules/BlockComponent/BlockComponent.tsx
+++ b/frontend/src/components/molecules/BlockComponent/BlockComponent.tsx
@@ -2,11 +2,13 @@
 /** @jsxRuntime classic */
 import { jsx, css, SerializedStyles } from '@emotion/react';
 import { useRef, useState, useEffect, useCallback, FormEvent } from 'react';
-import { Heading1, Heading2, Heading3 } from '../../atoms/Heading';
-import { Block, BlockType } from '../../../schemes';
+
+import { Heading } from '@components/atoms';
+import { Block, BlockType } from '@/schemes';
 
 const isGridOrColumn = (block: Block): boolean =>
   block.type === BlockType.GRID || block.type === BlockType.COLUMN;
+
 const blockCss = (): SerializedStyles => css`
   width: 100%;
   max-width: 1000px;
@@ -72,9 +74,9 @@ const ConvertBlock = (
     handleValue,
     content,
   };
-  if (type === 'Heading1') return <Heading1 {...compoProps} />;
-  if (type === 'Heading2') return <Heading2 {...compoProps} />;
-  if (type === 'Heading3') return <Heading3 {...compoProps} />;
+  if (type === 'Heading1') return <Heading.Heading1 {...compoProps} />;
+  if (type === 'Heading2') return <Heading.Heading2 {...compoProps} />;
+  if (type === 'Heading3') return <Heading.Heading3 {...compoProps} />;
   return (
     <div
       css={contentsCss(block)}

--- a/frontend/src/components/molecules/BlockComponent/index.ts
+++ b/frontend/src/components/molecules/BlockComponent/index.ts
@@ -1,1 +1,1 @@
-export * as BlockComponent from './BlockComponent';
+export { default } from './BlockComponent';

--- a/frontend/src/components/molecules/BlockHandler/BlockHandler.stories.tsx
+++ b/frontend/src/components/molecules/BlockHandler/BlockHandler.stories.tsx
@@ -2,9 +2,10 @@
 /** @jsxRuntime classic */
 import { jsx } from '@emotion/react';
 import React, { useState, useCallback } from 'react';
+
+import { Block, BlockType } from '@/schemes';
+import { BlockComponent } from '@components/molecules';
 import BlockHandler from '.';
-import { Block, BlockType } from '../../../schemes';
-import BlockComponent from '../BlockComponent/BlockComponent';
 
 const desc = {
   component: BlockHandler,

--- a/frontend/src/components/molecules/BlockHandler/BlockHandler.tsx
+++ b/frontend/src/components/molecules/BlockHandler/BlockHandler.tsx
@@ -3,8 +3,9 @@
 import { jsx } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
-import { ReactComponent as DraggableIcon } from '../../../assets/draggable.svg';
-import { ReactComponent as PlusIcon } from '../../../assets/plus.svg';
+
+import { ReactComponent as DraggableIcon } from '@assets/draggable.svg';
+import { ReactComponent as PlusIcon } from '@assets/plus.svg';
 
 const ButtonWrapper = styled.div`
   display: block;

--- a/frontend/src/components/molecules/Editor/Editor.stories.tsx
+++ b/frontend/src/components/molecules/Editor/Editor.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import Editor from './Editor';
-import { Page, Block, BlockType } from '../../../schemes';
+import { Page, Block, BlockType } from '@/schemes';
+import Editor from '.';
 
 const desc = {
   component: Editor,

--- a/frontend/src/components/molecules/Editor/Editor.tsx
+++ b/frontend/src/components/molecules/Editor/Editor.tsx
@@ -2,8 +2,8 @@
 /** @jsxRuntime classic */
 import { jsx, css, SerializedStyles } from '@emotion/react';
 
-import { Page, Block } from '../../../schemes';
-import BlockComponent from '../BlockComponent/BlockComponent';
+import { Page, Block } from '@/schemes';
+import { BlockComponent } from '@components/molecules';
 
 const wrapperCss = (): SerializedStyles => css`
   padding-left: calc(96px + env(safe-area-inset-left));

--- a/frontend/src/components/molecules/Header/Header.stories.tsx
+++ b/frontend/src/components/molecules/Header/Header.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import Header from './Header';
-import { Page } from '../../../schemes';
+import { Page } from '@/schemes';
+import Header from '.';
 
 const desc = {
   component: Header,

--- a/frontend/src/components/molecules/Header/Header.tsx
+++ b/frontend/src/components/molecules/Header/Header.tsx
@@ -3,12 +3,10 @@
 import { jsx, css, SerializedStyles } from '@emotion/react';
 import { useState } from 'react';
 
-import { Page } from '../../../schemes';
-import HeaderLink from '../../atoms/HeaderLink';
-import HeaderButton from '../../atoms/HeaderButton';
-import HeaderMenu from '../../organisms/HeaderMenu';
-import { ReactComponent as Dots } from '../../../assets/dots.svg';
-import { ReactComponent as Check } from '../../../assets/check.svg';
+import { Page } from '@/schemes';
+import { HeaderLink, HeaderButton } from '@components/atoms';
+import { ReactComponent as Dots } from '@assets/dots.svg';
+import { ReactComponent as Check } from '@assets/check.svg';
 
 const headerCss = (): SerializedStyles => css`
   width: 100%;

--- a/frontend/src/components/molecules/Menu/Menu.stories.tsx
+++ b/frontend/src/components/molecules/Menu/Menu.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import Menu from './Menu';
-import { Page } from '../../../schemes';
+import Menu from '.';
 
 const desc = {
   component: Menu,
@@ -9,7 +8,7 @@ const desc = {
 };
 
 export const Default = (): JSX.Element => {
-  return <Menu  />;
+  return <Menu />;
 };
 
 export default desc;

--- a/frontend/src/components/molecules/Menu/Menu.tsx
+++ b/frontend/src/components/molecules/Menu/Menu.tsx
@@ -2,8 +2,6 @@
 /** @jsxRuntime classic */
 import { jsx, css, SerializedStyles } from '@emotion/react';
 
-import { Page } from '../../../schemes';
-
 const wrapperCss = (): SerializedStyles => css`
   width: 30px;
   width: 240px;
@@ -17,9 +15,7 @@ const wrapperCss = (): SerializedStyles => css`
 interface Props {}
 
 function Menu(): JSX.Element {
-  return (
-    <div css={wrapperCss()}>menu</div>
-  );
+  return <div css={wrapperCss()}>menu</div>;
 }
 
 export default Menu;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -1,4 +1,5 @@
-export * as Header from './Header';
-export * as Editor from './Editor';
-export * as Menu from './Menu';
-export * as BlockComponent from './BlockComponent';
+export { default as Header } from './Header';
+export { default as Editor } from './Editor';
+export { default as Menu } from './Menu';
+export { default as BlockComponent } from './BlockComponent';
+export { default as BlockHandler } from './BlockHandler';

--- a/frontend/src/components/organisms/HeaderMenu/HeaderMenu.stories.tsx
+++ b/frontend/src/components/organisms/HeaderMenu/HeaderMenu.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import HeaderMenu from './HeaderMenu';
+import HeaderMenu from '.';
 
 const desc = {
   component: HeaderMenu,

--- a/frontend/src/components/organisms/HeaderMenu/HeaderMenu.tsx
+++ b/frontend/src/components/organisms/HeaderMenu/HeaderMenu.tsx
@@ -3,10 +3,10 @@
 import { jsx, css, SerializedStyles } from '@emotion/react';
 import { useState } from 'react';
 
-import { ReactComponent as HamburgerMenu } from '../../../assets/hamburgerMenu.svg';
-import { ReactComponent as DoubleChevronRight } from '../../../assets/doubleChevronRight.svg';
-import HeaderButton from '../../atoms/HeaderButton';
-import Menu from '../../molecules/Menu';
+import { HeaderButton } from '@components/atoms';
+import { Menu } from '@components/molecules';
+import { ReactComponent as HamburgerMenu } from '@assets/hamburgerMenu.svg';
+import { ReactComponent as DoubleChevronRight } from '@assets/doubleChevronRight.svg';
 
 const wrapperCss = (isMenuClosed: boolean): SerializedStyles => css`
   position: relative;

--- a/frontend/src/components/organisms/index.ts
+++ b/frontend/src/components/organisms/index.ts
@@ -1,1 +1,1 @@
-export * as HeaderMenu from './HeaderMenu';
+export { default as HeaderMenu } from './HeaderMenu';

--- a/frontend/src/components/pages/PageComponent/PageComponent.stories.tsx
+++ b/frontend/src/components/pages/PageComponent/PageComponent.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import PageComponent from './PageComponent';
-import { Page, Block, BlockType } from '../../../schemes';
+import { Page, Block, BlockType } from '@/schemes';
+import PageComponent from '.';
 
 const desc = {
   component: PageComponent,

--- a/frontend/src/components/pages/PageComponent/PageComponent.tsx
+++ b/frontend/src/components/pages/PageComponent/PageComponent.tsx
@@ -3,10 +3,9 @@
 import { jsx, css, SerializedStyles } from '@emotion/react';
 import { useState } from 'react';
 
-import { Page } from '../../../schemes';
-import Editor from '../../molecules/Editor';
-import Header from '../../molecules/Header';
-import HeaderMenu from '../../organisms/HeaderMenu';
+import { Page } from '@/schemes';
+import { Header, Editor } from '@components/molecules';
+import { HeaderMenu } from '@components/organisms';
 
 const staticMenuAreaCss = (): SerializedStyles => css`
   position: fixed;

--- a/frontend/src/components/pages/index.ts
+++ b/frontend/src/components/pages/index.ts
@@ -1,1 +1,1 @@
-export * as PageComponent from './PageComponent';
+export { default as PageComponent } from './PageComponent';

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,6 +3,6 @@
 import { jsx } from '@emotion/react';
 import ReactDOM from 'react-dom';
 
-import App from './App';
+import App from '@/App';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,5 +28,6 @@
   },
   "include": [
     "src"
-  ]
+  ],
+  "extends": "./tsconfig.paths.json"
 }

--- a/frontend/tsconfig.paths.json
+++ b/frontend/tsconfig.paths.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@asset/*": ["src/asset/*"],
+      "@utils/*": ["src/asset/*"],
+      "@component/*": ["src/components/*"],
+      "@atoms/*": ["src/components/atoms/*"],
+      "@molecules/*": ["src/components/molecules/*"],
+      "@organisms/*": ["src/components/organisms/*"],
+      "@pages/*": ["src/components/pages/*"]
+    }
+  }
+}

--- a/frontend/tsconfig.paths.json
+++ b/frontend/tsconfig.paths.json
@@ -3,9 +3,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
-      "@asset/*": ["src/asset/*"],
-      "@utils/*": ["src/asset/*"],
-      "@component/*": ["src/components/*"],
+      "@assets/*": ["src/assets/*"],
+      "@utils/*": ["src/utils/*"],
+      "@components/*": ["src/components/*"],
       "@atoms/*": ["src/components/atoms/*"],
       "@molecules/*": ["src/components/molecules/*"],
       "@organisms/*": ["src/components/organisms/*"],


### PR DESCRIPTION
# 프론트엔드 절대 경로 설정

## 해당 이슈 📎

#6 

## 변경 사항 🛠

구현내용 요약

- CRA TypeScript path alias 설정
  - 절대 경로 설정 파일 tsconfig.paths.json 추가
  - react-app-rewire & react-app-rewire-alias 설치
  - CRA 커스텀 빌드 설정 파일 config-overrides.js 추가
  - storybook 설정 파일 내 절대 경로 설정 추가
- components 모듈 내 import 경로 전환

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️
https://stackoverflow.com/questions/57070052/create-react-app-typescript-3-5-path-alias
