### PR TITLE
백엔드 API 통신을 위한 hooks 및 유틸리티 함수 추가

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -1,12 +1,13 @@
 {
   "plugins": [
-    "prettier",
-    "@typescript-eslint"
+    "@typescript-eslint",
+    "prettier"
   ],
   "extends": [
     "airbnb-typescript",
     "react-app",
-    "prettier"
+    "prettier",
+    "prettier/@typescript-eslint"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -36,7 +37,8 @@
     "import/extensions": 0,
     "import/no-unresolved": 0,
     "import/prefer-default-export": "off",
-    "jsx-a11y/no-static-element-interactions": 0
+    "jsx-a11y/no-static-element-interactions": 0,
+    "@typescript-eslint/indent": ["error", 2]
   },
   "settings": {
     "import/resolver": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6550,6 +6550,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
       "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ=="
     },
+    "axios": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,5 +91,6 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --fix"
-  }
+  },
+  "proxy": "http://localhost:4000"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^12.19.6",
     "@types/react": "^16.14.1",
     "@types/react-dom": "^16.9.10",
+    "axios": "^0.21.0",
     "babel-loader": "^8.1.0",
     "react": "^17.0.1",
     "react-app-rewire-alias": "^0.1.8",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 import { jsx, css, Global } from '@emotion/react';
 import { lazy, Suspense, useEffect, useState } from 'react';
-import { getPage } from '@/utils';
+import { fetchDummyData } from '@/utils';
 
 const PageComponent = lazy(() => import('@components/pages/PageComponent'));
 
@@ -10,7 +10,7 @@ function App(): JSX.Element {
   const [page, setPage] = useState(null);
   useEffect(() => {
     (async () => {
-      setPage(await getPage('1'));
+      setPage(await fetchDummyData('1'));
     })();
   }, []);
   return (

--- a/frontend/src/components/molecules/BlockComponent/BlockComponent.stories.tsx
+++ b/frontend/src/components/molecules/BlockComponent/BlockComponent.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { getPage } from '@/utils';
+import { fetchDummyData } from '@/utils';
 import BlockComponent from '.';
 
 const desc = {
@@ -12,7 +12,7 @@ export const Default = (): JSX.Element => {
   const [block, setBlock] = useState(null);
   useEffect(() => {
     (async () => {
-      setBlock((await getPage('1')).blockList[0]);
+      setBlock((await fetchDummyData('1')).blockList[0]);
     })();
   });
 
@@ -23,7 +23,7 @@ export const HasDescendants = (): JSX.Element => {
   const [block, setBlock] = useState(null);
   useEffect(() => {
     (async () => {
-      setBlock((await getPage('1')).blockList[1]);
+      setBlock((await fetchDummyData('1')).blockList[1]);
     })();
   });
   return <BlockComponent blockDTO={block} />;
@@ -33,7 +33,7 @@ export const Grid = (): JSX.Element => {
   const [block, setBlock] = useState(null);
   useEffect(() => {
     (async () => {
-      setBlock((await getPage('1')).blockList[2]);
+      setBlock((await fetchDummyData('1')).blockList[2]);
     })();
   });
   return <BlockComponent blockDTO={block} />;

--- a/frontend/src/components/molecules/BlockHandler/BlockHandler.stories.tsx
+++ b/frontend/src/components/molecules/BlockHandler/BlockHandler.stories.tsx
@@ -4,7 +4,7 @@ import { jsx } from '@emotion/react';
 import { useEffect, useState } from 'react';
 
 import { BlockComponent } from '@components/molecules';
-import { getPage } from '@/utils';
+import { fetchDummyData } from '@/utils';
 import BlockHandler from '.';
 
 const desc = {
@@ -16,7 +16,7 @@ export const Default = (): JSX.Element => {
   const [block, setBlock] = useState(null);
   useEffect(() => {
     (async () => {
-      setBlock((await getPage('1')).blockList[2]);
+      setBlock((await fetchDummyData('1')).blockList[2]);
     })();
   });
   return (

--- a/frontend/src/components/molecules/Editor/Editor.stories.tsx
+++ b/frontend/src/components/molecules/Editor/Editor.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { getPage } from '@/utils';
+import { fetchDummyData } from '@/utils';
 import Editor from '.';
 
 const desc = {
@@ -12,7 +12,7 @@ export const Default = (): JSX.Element => {
   const [page, setPage] = useState(null);
   useEffect(() => {
     (async () => {
-      setPage(await getPage('1'));
+      setPage(await fetchDummyData('1'));
     })();
   });
   return <Editor {...{ page }} />;

--- a/frontend/src/components/molecules/Header/Header.stories.tsx
+++ b/frontend/src/components/molecules/Header/Header.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { getPage } from '@/utils';
+import { fetchDummyData } from '@/utils';
 import Header from '.';
 
 const desc = {
@@ -12,7 +12,7 @@ export const Default = (): JSX.Element => {
   const [page, setPage] = useState(null);
   useEffect(() => {
     (async () => {
-      setPage(await getPage('1'));
+      setPage(await fetchDummyData('1'));
     })();
   });
   return <Header page={page} menuClosed />;
@@ -22,7 +22,7 @@ export const MenuOpened = (): JSX.Element => {
   const [page, setPage] = useState(null);
   useEffect(() => {
     (async () => {
-      setPage(await getPage('1'));
+      setPage(await fetchDummyData('1'));
     })();
   });
   return <Header page={page} menuClosed={false} />;

--- a/frontend/src/components/molecules/Menu/Menu.tsx
+++ b/frontend/src/components/molecules/Menu/Menu.tsx
@@ -1,6 +1,11 @@
 /** @jsx jsx */
 /** @jsxRuntime classic */
 import { jsx, css, SerializedStyles } from '@emotion/react';
+import { Suspense } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { pagesState } from '@/stores';
+import { createPage } from '@/utils';
 
 const wrapperCss = (): SerializedStyles => css`
   width: 30px;
@@ -14,8 +19,29 @@ const wrapperCss = (): SerializedStyles => css`
 
 interface Props {}
 
-function Menu(): JSX.Element {
-  return <div css={wrapperCss()}>menu</div>;
+function Menu({}: Props): JSX.Element {
+  const [pages, setPages] = useRecoilState(pagesState);
+
+  const handleClick = () => {
+    (async () => {
+      const { pages: updatedPages } = await createPage();
+      setPages(updatedPages);
+    })();
+  };
+
+  return (
+    <div css={wrapperCss()}>
+      <div>menu</div>
+      <button type="button" onClick={handleClick}>
+        +
+      </button>
+      <Suspense fallback={<div>Loading...</div>}>
+        {pages.map((page) => (
+          <div key={page.id}>{` * ${page.title || 'Untitled'}`}</div>
+        ))}
+      </Suspense>
+    </div>
+  );
 }
 
 export default Menu;

--- a/frontend/src/components/pages/PageComponent/PageComponent.stories.tsx
+++ b/frontend/src/components/pages/PageComponent/PageComponent.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { getPage } from '@/utils';
+import { fetchDummyData } from '@/utils';
 import PageComponent from '.';
 
 const desc = {
@@ -12,7 +12,7 @@ export const Default = (): JSX.Element => {
   const [page, setPage] = useState(null);
   useEffect(() => {
     (async () => {
-      setPage(await getPage('1'));
+      setPage(await fetchDummyData('1'));
     })();
   });
   return <PageComponent page={page} menuClosed />;

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useCommand } from './useCommand';
 export { default as useFamily } from './useFamily';
+export { useApi } from './useApi';

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+export const useApi = (params: { initialUrl: string; initialData?: any }) => {
+  const [url, setUrl] = useState(params.initialUrl);
+  const [data, setData] = useState(params.initialData ?? null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const [refreshToggle, setRefreshToggle] = useState(true);
+
+  const refresh = () => setRefreshToggle(!refreshToggle);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsError(false);
+      setIsLoading(true);
+
+      try {
+        const res = await axios.get(`/api/${url}`);
+        setData(res.data);
+      } catch (error) {
+        setIsError(true);
+      }
+
+      setIsLoading(false);
+    };
+
+    fetchData();
+  }, [url, refreshToggle]);
+
+  return [
+    { data, isLoading, isError },
+    { setUrl, refresh },
+  ];
+};

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -1,8 +1,1 @@
-export {
-  pageState,
-  blockState,
-  hoverState,
-  focusState,
-  caretState,
-  blockRefState,
-} from './page';
+export * from './page';

--- a/frontend/src/stores/page.ts
+++ b/frontend/src/stores/page.ts
@@ -1,7 +1,7 @@
-import { atom, atomFamily } from 'recoil';
+import { atom, atomFamily, RecoilState } from 'recoil';
 
-import { IdType } from '@/schemes';
-import { fetchDummyData } from '@/utils';
+import { IdType, Page } from '@/schemes';
+import { fetchDummyData, readPages } from '@/utils';
 
 enum StateType {
   PAGE_STATE = 'pageState',
@@ -10,6 +10,7 @@ enum StateType {
   FOCUS_STATE = 'focusState',
   CARET_STATE = 'caretState',
   BLOCK_REF_STATE = 'blockRefState',
+  PAGES_STATE = 'pagesState',
 }
 
 export const pageState = atomFamily({
@@ -40,4 +41,9 @@ export const caretState = atom({
 export const focusState = atom({
   key: StateType.FOCUS_STATE,
   default: null,
+});
+
+export const pagesState = atom({
+  key: StateType.PAGES_STATE,
+  default: readPages(),
 });

--- a/frontend/src/stores/page.ts
+++ b/frontend/src/stores/page.ts
@@ -1,7 +1,7 @@
 import { atom, atomFamily } from 'recoil';
 
 import { IdType } from '@/schemes';
-import { getPage } from '@/utils';
+import { fetchDummyData } from '@/utils';
 
 enum StateType {
   PAGE_STATE = 'pageState',
@@ -14,7 +14,7 @@ enum StateType {
 
 export const pageState = atomFamily({
   key: StateType.PAGE_STATE,
-  default: async (id: IdType) => getPage(id),
+  default: async (id: IdType) => fetchDummyData(id),
 });
 
 export const blockState = atomFamily({

--- a/frontend/src/utils/blockApis.ts
+++ b/frontend/src/utils/blockApis.ts
@@ -1,0 +1,164 @@
+import axios, { AxiosResponse } from 'axios';
+import { Page, Block } from '@/schemes';
+
+const BASE_URL = '/api/blocks';
+
+type ErrorReturns = {
+  error?: 1 | true;
+  message?: string;
+};
+
+type CreateBlockToPageParams = {
+  block: Block;
+  pageId: string;
+  targetIndex?: number;
+};
+
+type CreateBlockToPageReturns = {
+  block: Block;
+  page: Page;
+  parent: null;
+} & ErrorReturns;
+
+export const createBlockToPage = async (
+  params: CreateBlockToPageParams,
+): Promise<CreateBlockToPageReturns> =>
+  (await axios.post(BASE_URL, params))?.data;
+
+export const createBlockToPageSync = (
+  params: CreateBlockToPageParams,
+  callback: (res: AxiosResponse<CreateBlockToPageReturns>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .post(BASE_URL)
+    .then(callback)
+    .catch(errorHandler ?? console.error);
+
+type CreateBlockToBlockParams = {
+  block: Block;
+  parent: Block;
+  targetIndex?: number;
+};
+
+type CreateBlockToBlockReturns = {
+  block: Block;
+  parent: Block;
+  page: null;
+} & ErrorReturns;
+
+export const createBlockToBlock = async (
+  params: CreateBlockToBlockParams,
+): Promise<CreateBlockToBlockReturns> =>
+  (await axios.post(BASE_URL, params))?.data;
+
+export const createBlockToBlockSync = (
+  params: CreateBlockToBlockParams,
+  callback: (res: AxiosResponse<CreateBlockToBlockReturns>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .post(BASE_URL)
+    .then(callback)
+    .catch(errorHandler ?? console.error);
+
+type UpdateBlockParams = {
+  block: Block;
+};
+
+type UpdateBlockReturns = {
+  block: Block;
+  parent: null;
+  page: null;
+} & ErrorReturns;
+
+export const updateBlock = async (
+  params: UpdateBlockParams,
+): Promise<UpdateBlockReturns> => (await axios.patch(BASE_URL, params))?.data;
+
+export const updateBlockSync = (
+  params: UpdateBlockParams,
+  callback: (res: AxiosResponse<UpdateBlockReturns>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .patch(BASE_URL)
+    .then(callback)
+    .catch(errorHandler ?? console.error);
+
+type MoveToPageParams = {
+  block: Block;
+  pageId: string;
+  targetIndex?: number;
+};
+
+type MoveToPageReturns = {
+  block: Block;
+  page: Page;
+  parent: null;
+} & ErrorReturns;
+
+export const moveToPage = async (
+  params: MoveToPageParams,
+): Promise<MoveToPageReturns> => (await axios.patch(BASE_URL, params))?.data;
+
+export const moveToPageSync = (
+  params: MoveToPageParams,
+  callback: (res: AxiosResponse<MoveToPageReturns>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .patch(BASE_URL)
+    .then(callback)
+    .catch(errorHandler ?? console.error);
+
+type MoveToBlockParams = {
+  block: Block;
+  parent: Block;
+  targetIndex?: number;
+};
+
+type MoveToBlockReturns = {
+  block: Block;
+  parent: Block;
+  page: null;
+} & ErrorReturns;
+
+export const moveToBlock = async (
+  params: MoveToBlockParams,
+): Promise<MoveToBlockReturns> => (await axios.patch(BASE_URL, params))?.data;
+
+export const moveToBlockSync = (
+  params: MoveToBlockParams,
+  callback: (res: AxiosResponse<MoveToBlockReturns>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .patch(BASE_URL)
+    .then(callback)
+    .catch(errorHandler ?? console.error);
+
+type DeleteBlockParams = {
+  block: Block;
+  remove?: 0 | 1 | false | true;
+};
+
+type DeleteBlockReturns = {
+  block: null;
+  page: Page | null;
+  parent: Block | null;
+} & ErrorReturns;
+
+export const deleteBlock = async (
+  params: DeleteBlockParams,
+): Promise<DeleteBlockReturns> => (await axios.patch(BASE_URL, params))?.data;
+
+export const deleteBlockSync = (
+  params: DeleteBlockParams,
+  callback: (res: AxiosResponse<DeleteBlockReturns>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .patch(BASE_URL)
+    .then(callback)
+    .catch(errorHandler ?? console.error);

--- a/frontend/src/utils/fetchDummyData.ts
+++ b/frontend/src/utils/fetchDummyData.ts
@@ -1,12 +1,6 @@
 import { Block, BlockType, IdType, Page } from '@/schemes';
 
-// export const getPage = async (pageId: KeyType): Promise<Page> => {
-//   const url = '';
-//   const res = await fetch(`${url}/${pageId}`);
-//   return res.json();
-// };
-
-export const getPage = (pageId: IdType): Promise<Page> =>
+export const fetchDummyData = (pageId: IdType): Promise<Page> =>
   new Promise((resolve) => {
     const block01: Block = {
       id: '1',

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,2 +1,2 @@
-export { getPage } from './fetchApi';
+export { fetchDummyData } from './fetchDummyData';
 export { regex, fontSize, placeHolder, listComponent } from './blockContent';

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,2 +1,4 @@
 export { fetchDummyData } from './fetchDummyData';
 export { regex, fontSize, placeHolder, listComponent } from './blockContent';
+export * from './pageApis';
+export * from './blockApis';

--- a/frontend/src/utils/pageApis.ts
+++ b/frontend/src/utils/pageApis.ts
@@ -1,0 +1,103 @@
+import axios, { AxiosResponse } from 'axios';
+import { Page } from '@/schemes';
+
+const BASE_URL = '/api/pages';
+
+type ErrorReturns = {
+  error?: 1 | true;
+  message?: string;
+};
+
+type CreatePageReturns = {
+  page: Page;
+  pages: Page[];
+} & ErrorReturns;
+
+export const createPage = async (): Promise<CreatePageReturns> =>
+  (await axios.post(BASE_URL))?.data;
+
+export const createPageSync = (
+  callback: (res: AxiosResponse<CreatePageReturns>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .post(BASE_URL)
+    .then(callback)
+    .catch(errorHandler ?? console.error);
+
+// type ReadPagesReturns = Page[] & ErrorReturns;
+
+export const readPages = async (): Promise<Page[]> =>
+  (await axios.get(BASE_URL))?.data;
+
+export const readPagesSync = (
+  callback: (res: AxiosResponse<Page[]>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .get(BASE_URL)
+    .then(callback)
+    .catch(errorHandler ?? console.error);
+
+type ReadPageParams = {
+  id: string;
+};
+
+// type ReadPageReturns = Page & ErrorReturns;
+
+export const readPage = async <T extends ReadPageParams>(
+  params: T,
+): Promise<Page> => (await axios.get(`${BASE_URL}/id/${params.id}`))?.data;
+
+export const readPageSync = <T extends ReadPageParams>(
+  params: T,
+  callback: (res: AxiosResponse<Page>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .get(`${BASE_URL}/id/${params.id}`)
+    .then(callback)
+    .catch(errorHandler ?? console.error);
+
+type UpdatePageParams = {
+  id: string;
+  title: string;
+};
+
+type UpdatePageReturns = Page & ErrorReturns;
+
+export const updatePage = async <T extends UpdatePageParams>(
+  params: T,
+): Promise<UpdatePageReturns> =>
+  (await axios.patch(`${BASE_URL}/id/${params.id}`, params))?.data;
+
+export const updatePageSync = <T extends UpdatePageParams>(
+  params: T,
+  callback: (res: AxiosResponse<UpdatePageReturns>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .patch(`${BASE_URL}/id/${params.id}`, params)
+    .then(callback)
+    .catch(errorHandler ?? console.error);
+
+type DeletePageParams = {
+  id: string;
+};
+
+type DeletePageReturns = Page[] & ErrorReturns;
+
+export const deletePage = async <T extends DeletePageParams>(
+  params: T,
+): Promise<DeletePageReturns> =>
+  (await axios.delete(`${BASE_URL}/id/${params.id}`))?.data;
+
+export const deletePageSync = <T extends DeletePageParams>(
+  params: T,
+  callback: (res: AxiosResponse<DeletePageReturns>) => void,
+  errorHandler?: (err: Error) => void,
+) =>
+  axios
+    .delete(`${BASE_URL}/id/${params.id}`)
+    .then(callback)
+    .catch(errorHandler ?? console.error);


### PR DESCRIPTION
# 제목

## 해당 이슈 📎

#76 

## 변경 사항 🛠

- 유틸 함수 명 getPage -> fetchDummyData 변경
- axios 의존성 추가
- proxy 설정 추가
- eslint 설정 수정 및 추가
- 데이터 조회용 API 훅 구현
- page 관련 API 호출 함수 구현
- block 관련 API 호출 함수 구현
- pages에 대한 global state 관리용 atom 추가
- pages atom을 사용한 Menu 컴포넌트 프로토타이핑

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

