### PR TITLE
Enter Key interaction에 기존 Block의 value를 slice해 할당하는 로직 추가

### DIFF
--- a/frontend/src/hooks/useCommand.tsx
+++ b/frontend/src/hooks/useCommand.tsx
@@ -25,6 +25,14 @@ const useCommand = () => {
     sel.collapse(node, offset > length ? length : offset);
   };
 
+  const getSlicedValueToCaretOffset = () => {
+    const { focusNode, focusOffset } = window.getSelection();
+    return [
+      focusNode.textContent.slice(0, focusOffset),
+      focusNode.textContent.slice(focusOffset, Infinity),
+    ];
+  };
+
   const dispatcher = (key: String) => {
     switch (key) {
       case 'ArrowUp': {
@@ -48,7 +56,9 @@ const useCommand = () => {
         break;
       }
       case 'Enter': {
-        setFocus(familyFunc.makeNewBlock());
+        const [before, after] = getSlicedValueToCaretOffset();
+        familyFunc.setBlockValue(before);
+        setFocus(familyFunc.makeNewBlock({ value: after }));
         break;
       }
     }

--- a/frontend/src/hooks/useManager.tsx
+++ b/frontend/src/hooks/useManager.tsx
@@ -6,7 +6,8 @@ import { Block, BlockType, BlockFamily } from '@/schemes';
 interface ManagerFunc {
   getNextBlock: () => Block | null;
   getPrevBlock: () => Block | null;
-  makeNewBlock: () => Block | null;
+  makeNewBlock: (option?: any, blockType?: BlockType) => Block | null;
+  setBlockValue: (value: string) => void;
 }
 
 const findLastDescendant = (targetBlock: Block) => {
@@ -32,6 +33,7 @@ const useManger = (blockId: string): [BlockFamily, ManagerFunc] => {
   const parentIndex = (grandParent?.children || page.blockList).findIndex(
     (_block) => _block.id === parent?.id,
   );
+
   const getNextBlock = () => {
     if (children.length) {
       /* 자식이 있을 때 첫번째 자식이 다음 block 이다.  */
@@ -61,6 +63,7 @@ const useManger = (blockId: string): [BlockFamily, ManagerFunc] => {
       return siblings[blockIndex + 1];
     }
   };
+
   const getPrevBlock = () => {
     if (blockIndex) {
       /** blockIndex가 0이 아니면 이전 형제에서 prev block을 찾을 수 있다. */
@@ -111,12 +114,20 @@ const useManger = (blockId: string): [BlockFamily, ManagerFunc] => {
       return null;
     }
   };
-  const makeNewBlock = (blockType: BlockType = BlockType.TEXT) => {
+
+  const setBlockValue = (value: string) => {
+    setBlock({ ...block, value });
+  };
+
+  const makeNewBlock = (
+    option: any = {},
+    blockType: BlockType = BlockType.TEXT,
+  ) => {
     if (children.length) {
       const newBlock: Block = {
         id: `${block.id}${children.length + 1}_${Date.now()}`,
         type: blockType,
-        value: '',
+        value: option.value ?? '',
         children: [],
         parentBlockId: parent?.id ?? null,
         pageId: page.id,
@@ -128,7 +139,7 @@ const useManger = (blockId: string): [BlockFamily, ManagerFunc] => {
     const newBlock: Block = {
       id: `${parent?.id ?? ''}${siblings.length + 1}_${Date.now()}`,
       type: blockType,
-      value: '',
+      value: option.value ?? '',
       children: [],
       parentBlockId: parent?.id ?? null,
       pageId: page.id,
@@ -144,6 +155,7 @@ const useManger = (blockId: string): [BlockFamily, ManagerFunc] => {
         });
     return newBlock;
   };
+
   return [
     {
       block,
@@ -160,6 +172,7 @@ const useManger = (blockId: string): [BlockFamily, ManagerFunc] => {
       getNextBlock,
       getPrevBlock,
       makeNewBlock,
+      setBlockValue,
     },
   ];
 };


### PR DESCRIPTION
# Enter Key interaction에 기존 Block의 value를 slice해 할당하는 로직 추가

## 해당 이슈 📎

#74

## 변경 사항 🛠

구현내용 요약

- Enter Key 입력 시 기존 Block의 value를 slice해 할당하는 로직 추가
- Block의 Value를 수정하는 기능 구현
- focus된 Block의 value를 caret offset을 기준으로 잘라서 배열로 반환하는 함수 구현

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

